### PR TITLE
objectupdate: rte: continue minimization of manifests

### DIFF
--- a/pkg/manifests/yaml/rte/daemonset.yaml
+++ b/pkg/manifests/yaml/rte/daemonset.yaml
@@ -39,8 +39,6 @@ spec:
               fieldPath: metadata.name
         - name: REFERENCE_CONTAINER_NAME
           value: shared-pool-container
-        - name: METRICS_PORT
-          value: "2112"
         volumeMounts:
           - name: host-sys
             mountPath: "/host-sys"

--- a/pkg/objectupdate/find.go
+++ b/pkg/objectupdate/find.go
@@ -21,10 +21,30 @@ import (
 )
 
 func FindContainerByName(conts []corev1.Container, name string) *corev1.Container {
-	for i := range conts {
-		cont := &conts[i]
+	for idx := range conts {
+		cont := &conts[idx]
 		if cont.Name == name {
 			return cont
+		}
+	}
+	return nil
+}
+
+func FindContainerEnvVarByName(envs []corev1.EnvVar, name string) *corev1.EnvVar {
+	for idx := range envs {
+		env := &envs[idx]
+		if env.Name == name {
+			return env
+		}
+	}
+	return nil
+}
+
+func FindContainerPortByName(ports []corev1.ContainerPort, name string) *corev1.ContainerPort {
+	for idx := range ports {
+		cp := &ports[idx]
+		if cp.Name == name {
+			return cp
 		}
 	}
 	return nil

--- a/pkg/objectupdate/find_test.go
+++ b/pkg/objectupdate/find_test.go
@@ -147,3 +147,136 @@ func TestFindContainerByNameMutableDeployment(t *testing.T) {
 		t.Fatalf("failed to mutate through the FindContainerByName reference")
 	}
 }
+
+func TestFindContainerEnvVarByNameMutablePod(t *testing.T) {
+	testEnvVarName := "TEST_FOO_BAR"
+
+	pod := corev1.Pod{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "foo",
+					Env: []corev1.EnvVar{
+						{
+							Name:  testEnvVarName,
+							Value: "33",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	got := FindContainerEnvVarByName(pod.Spec.Containers[0].Env, testEnvVarName)
+	if got == nil {
+		t.Fatalf("missing container env var")
+	}
+
+	newValue := "42"
+	got.Value = newValue
+	if pod.Spec.Containers[0].Env[0].Value != newValue {
+		t.Fatalf("failed to mutate through the FindContainerEnvVarByName reference")
+	}
+}
+
+func TestFindContainerEnvVarByNameMutableDeployment(t *testing.T) {
+	testEnvVarName := "FIZZBUZZ"
+
+	dp := appsv1.Deployment{
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "foo",
+							Env: []corev1.EnvVar{
+								{
+									Name:  testEnvVarName,
+									Value: "27",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	got := FindContainerEnvVarByName(dp.Spec.Template.Spec.Containers[0].Env, testEnvVarName)
+	if got == nil {
+		t.Fatalf("missing container env var")
+	}
+
+	newValue := "42"
+	got.Value = newValue
+	if dp.Spec.Template.Spec.Containers[0].Env[0].Value != newValue {
+		t.Fatalf("failed to mutate through the FindContainerEnvVarByName reference")
+	}
+}
+
+func TestFindContainerPortByNameMutablePod(t *testing.T) {
+	testPortName := "foo-port"
+
+	pod := corev1.Pod{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "foo",
+					Ports: []corev1.ContainerPort{
+						{
+							Name:          testPortName,
+							ContainerPort: int32(12345),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	got := FindContainerPortByName(pod.Spec.Containers[0].Ports, testPortName)
+	if got == nil {
+		t.Fatalf("missing container env var")
+	}
+
+	newValue := int32(42224)
+	got.ContainerPort = newValue
+	if pod.Spec.Containers[0].Ports[0].ContainerPort != newValue {
+		t.Fatalf("failed to mutate through the FindContainerPortByName reference")
+	}
+}
+
+func TestFindContainerPortByNameMutableDeployment(t *testing.T) {
+	testPortName := "bar-port"
+
+	dp := appsv1.Deployment{
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "foo",
+
+							Ports: []corev1.ContainerPort{
+								{
+									Name:          testPortName,
+									ContainerPort: int32(12345),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	got := FindContainerPortByName(dp.Spec.Template.Spec.Containers[0].Ports, testPortName)
+	if got == nil {
+		t.Fatalf("missing container env var")
+	}
+
+	newValue := int32(24242)
+	got.ContainerPort = newValue
+	if dp.Spec.Template.Spec.Containers[0].Ports[0].ContainerPort != newValue {
+		t.Fatalf("failed to mutate through the FindContainerPortByName reference")
+	}
+}

--- a/pkg/objectupdate/rte/rte.go
+++ b/pkg/objectupdate/rte/rte.go
@@ -34,9 +34,15 @@ import (
 )
 
 const (
-	metricsPort        = 2112
-	rteConfigMountName = "rte-config-volume"
-	RTEConfigMapName   = "rte-config"
+	metricsPort                  = 2112
+	metricsPortEnvVarName        = "METRICS_PORT"
+	metricsPortContainerPortName = "metrics-port"
+)
+
+const (
+	RTEConfigMapName         = "rte-config"
+	rteConfigMountName       = "rte-config-volume"
+	rteConfigMountPathLegacy = "/etc/resource-topology-exporter/"
 )
 
 const (
@@ -46,6 +52,7 @@ const (
 	rteKubeletDirVolumeName      = "host-var-lib-kubelet"
 	rteNotifierFileName          = "notify"
 	hostNotifierDir              = "/run/rte"
+	kubeletDataDir               = "/var/lib/kubelet"
 	sccAnnotation                = "openshift.io/required-scc"
 )
 
@@ -53,9 +60,11 @@ func ContainerConfig(podSpec *corev1.PodSpec, cnt *corev1.Container, configMapNa
 	cnt.VolumeMounts = append(cnt.VolumeMounts,
 		corev1.VolumeMount{
 			Name:      rteConfigMountName,
-			MountPath: "/etc/resource-topology-exporter/",
+			MountPath: rteConfigMountPathLegacy,
 		},
 	)
+
+	var true_ bool = true
 	podSpec.Volumes = append(podSpec.Volumes,
 		corev1.Volume{
 			Name: rteConfigMountName,
@@ -64,7 +73,7 @@ func ContainerConfig(podSpec *corev1.PodSpec, cnt *corev1.Container, configMapNa
 					LocalObjectReference: corev1.LocalObjectReference{
 						Name: configMapName,
 					},
-					Optional: newBool(true),
+					Optional: &true_,
 				},
 			},
 		},
@@ -73,112 +82,31 @@ func ContainerConfig(podSpec *corev1.PodSpec, cnt *corev1.Container, configMapNa
 
 func DaemonSet(ds *appsv1.DaemonSet, plat platform.Platform, configMapName string, opts options.DaemonSet) {
 	podSpec := &ds.Spec.Template.Spec
-	if cntSpec := objectupdate.FindContainerByName(ds.Spec.Template.Spec.Containers, manifests.ContainerNameRTE); cntSpec != nil {
-		imgs := images.Get()
-		cntSpec.Image = imgs.ResourceTopologyExporter
-
-		cntSpec.ImagePullPolicy = corev1.PullAlways
-		if opts.PullIfNotPresent {
-			cntSpec.ImagePullPolicy = corev1.PullIfNotPresent
-		}
-
-		if configMapName != "" {
-			ContainerConfig(podSpec, cntSpec, configMapName)
-		}
-
-		var rtePodVolumes []corev1.Volume
-		var rteContainerVolumeMounts []corev1.VolumeMount
-
-		if opts.NotificationEnable {
-			hostPathDirectoryOrCreate := corev1.HostPathDirectoryOrCreate
-			rtePodVolumes = append(rtePodVolumes, corev1.Volume{
-				// notifier file volume
-				Name: rteNotifierVolumeName,
-				VolumeSource: corev1.VolumeSource{
-					HostPath: &corev1.HostPathVolumeSource{
-						Path: hostNotifierDir,
-						Type: &hostPathDirectoryOrCreate,
-					},
-				},
-			})
-			rteContainerVolumeMounts = append(rteContainerVolumeMounts, corev1.VolumeMount{
-				Name:      rteNotifierVolumeName,
-				MountPath: filepath.Join("/", rteNotifierVolumeName),
-			})
-		}
-
-		if plat == platform.Kubernetes {
-			hostPathDirectory := corev1.HostPathDirectory
-			rtePodVolumes = append(rtePodVolumes, corev1.Volume{
-				Name: rteKubeletDirVolumeName,
-				VolumeSource: corev1.VolumeSource{
-					HostPath: &corev1.HostPathVolumeSource{
-						Path: "/var/lib/kubelet",
-						Type: &hostPathDirectory,
-					},
-				},
-			})
-			rteContainerVolumeMounts = append(rteContainerVolumeMounts, corev1.VolumeMount{
-				Name:      rteKubeletDirVolumeName,
-				ReadOnly:  true,
-				MountPath: filepath.Join("/", rteKubeletDirVolumeName),
-			})
-		}
-
-		flags := flagcodec.ParseArgvKeyValue(cntSpec.Args, flagcodec.WithFlagNormalization)
-		flags.SetOption("-v", fmt.Sprintf("%d", opts.Verbose))
-		if opts.UpdateInterval > 0 {
-			flags.SetOption("--sleep-interval", fmt.Sprintf("%v", opts.UpdateInterval))
-		} else {
-			flags.Delete("--sleep-interval")
-		}
-		if opts.NotificationEnable {
-			flags.SetOption("--notify-file", fmt.Sprintf("/%s/%s", rteNotifierVolumeName, rteNotifierFileName))
-		}
-
-		flags.SetOption("--pods-fingerprint", strconv.FormatBool(opts.PFPEnable))
-
-		if plat == platform.Kubernetes {
-			flags.SetOption("--kubelet-config-file", fmt.Sprintf("/%s/config.yaml", rteKubeletDirVolumeName))
-		}
-		cntSpec.Args = flags.Argv()
-
-		cntSpec.VolumeMounts = append(cntSpec.VolumeMounts, rteContainerVolumeMounts...)
-		ds.Spec.Template.Spec.Volumes = append(ds.Spec.Template.Spec.Volumes, rtePodVolumes...)
-	}
-
 	if opts.NodeSelector != nil {
 		podSpec.NodeSelector = opts.NodeSelector.MatchLabels
 	}
-	MetricsPort(ds, metricsPort)
-}
 
-func MetricsPort(ds *appsv1.DaemonSet, pNum int) {
 	cntSpec := objectupdate.FindContainerByName(ds.Spec.Template.Spec.Containers, manifests.ContainerNameRTE)
 	if cntSpec == nil {
-		return
+		return // should never happen
 	}
 
-	pNumAsStr := strconv.Itoa(pNum)
+	daemonSetContainerConfig(podSpec, cntSpec, plat, configMapName, opts)
+}
 
-	for idx, env := range cntSpec.Env {
-		if env.Name == "METRICS_PORT" {
-			cntSpec.Env[idx].Value = pNumAsStr
-		}
+func MetricsPort(ds *appsv1.DaemonSet, portNum int) {
+	cntSpec := objectupdate.FindContainerByName(ds.Spec.Template.Spec.Containers, manifests.ContainerNameRTE)
+	if cntSpec == nil {
+		return // should never happen
 	}
 
-	cp := []corev1.ContainerPort{{
-		Name:          "metrics-port",
-		ContainerPort: int32(pNum),
-	},
-	}
-	cntSpec.Ports = cp
+	metricsPortForContainer(cntSpec, portNum)
 }
 
 func SecurityContext(ds *appsv1.DaemonSet, selinuxContextType string) {
 	cntSpec := objectupdate.FindContainerByName(ds.Spec.Template.Spec.Containers, manifests.ContainerNameRTE)
 	if cntSpec == nil {
-		return
+		return // should never happen
 	}
 
 	// this is needed to put watches in the kubelet state dirs AND
@@ -200,29 +128,129 @@ type SecurityContextOptions struct {
 func SecurityContextWithOpts(ds *appsv1.DaemonSet, opts SecurityContextOptions) {
 	cntSpec := objectupdate.FindContainerByName(ds.Spec.Template.Spec.Containers, manifests.ContainerNameRTE)
 	if cntSpec == nil {
-		return
+		return // should never happen
 	}
+	_ = securityContextForContainer(&ds.Spec.Template, cntSpec, opts)
+}
 
-	// this is needed to put watches in the kubelet state dirs AND
-	// to open the podresources socket in R/W mode
+func securityContextForContainer(podTmpl *corev1.PodTemplateSpec, cntSpec *corev1.Container, opts SecurityContextOptions) error {
+	// mandatory settings
+
+	// this is needed to put watches in the kubelet state dirs AND to open the podresources socket in R/W mode
+	if opts.SELinuxContextType == "" {
+		return fmt.Errorf("missing SELinuxContextType")
+	}
 	if cntSpec.SecurityContext == nil {
 		cntSpec.SecurityContext = &corev1.SecurityContext{}
 	}
-	if opts.SELinuxContextType != "" {
-		cntSpec.SecurityContext.SELinuxOptions = &corev1.SELinuxOptions{
-			Type:  opts.SELinuxContextType,
-			Level: selinuxassets.RTEContextLevel,
-		}
+	cntSpec.SecurityContext.SELinuxOptions = &corev1.SELinuxOptions{
+		Type:  opts.SELinuxContextType,
+		Level: selinuxassets.RTEContextLevel,
 	}
-
-	if ds.Spec.Template.ObjectMeta.Annotations == nil {
-		ds.Spec.Template.ObjectMeta.Annotations = make(map[string]string)
-	}
+	// optional settings
 	if opts.SecurityContextName != "" {
-		ds.Spec.Template.ObjectMeta.Annotations[sccAnnotation] = opts.SecurityContextName
+		if podTmpl.ObjectMeta.Annotations == nil {
+			podTmpl.ObjectMeta.Annotations = make(map[string]string)
+		}
+		podTmpl.ObjectMeta.Annotations[sccAnnotation] = opts.SecurityContextName
 	}
+	return nil
 }
 
-func newBool(val bool) *bool {
-	return &val
+func daemonSetContainerConfig(podSpec *corev1.PodSpec, cntSpec *corev1.Container, plat platform.Platform, configMapName string, opts options.DaemonSet) {
+	metricsPortForContainer(cntSpec, metricsPort)
+
+	imgs := images.Get()
+	cntSpec.Image = imgs.ResourceTopologyExporter
+
+	cntSpec.ImagePullPolicy = corev1.PullAlways
+	if opts.PullIfNotPresent {
+		cntSpec.ImagePullPolicy = corev1.PullIfNotPresent
+	}
+
+	if configMapName != "" {
+		ContainerConfig(podSpec, cntSpec, configMapName)
+	}
+
+	var rtePodVolumes []corev1.Volume
+	var rteContainerVolumeMounts []corev1.VolumeMount
+
+	if opts.NotificationEnable {
+		hostPathDirectoryOrCreate := corev1.HostPathDirectoryOrCreate
+		rtePodVolumes = append(rtePodVolumes, corev1.Volume{
+			// notifier file volume
+			Name: rteNotifierVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				HostPath: &corev1.HostPathVolumeSource{
+					Path: hostNotifierDir,
+					Type: &hostPathDirectoryOrCreate,
+				},
+			},
+		})
+		rteContainerVolumeMounts = append(rteContainerVolumeMounts, corev1.VolumeMount{
+			Name:      rteNotifierVolumeName,
+			MountPath: filepath.Join("/", rteNotifierVolumeName),
+		})
+	}
+
+	if plat == platform.Kubernetes {
+		hostPathDirectory := corev1.HostPathDirectory
+		rtePodVolumes = append(rtePodVolumes, corev1.Volume{
+			Name: rteKubeletDirVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				HostPath: &corev1.HostPathVolumeSource{
+					Path: kubeletDataDir,
+					Type: &hostPathDirectory,
+				},
+			},
+		})
+		rteContainerVolumeMounts = append(rteContainerVolumeMounts, corev1.VolumeMount{
+			Name:      rteKubeletDirVolumeName,
+			ReadOnly:  true,
+			MountPath: filepath.Join("/", rteKubeletDirVolumeName),
+		})
+	}
+
+	flags := flagcodec.ParseArgvKeyValue(cntSpec.Args, flagcodec.WithFlagNormalization)
+	flags.SetOption("-v", fmt.Sprintf("%d", opts.Verbose))
+	if opts.UpdateInterval > 0 {
+		flags.SetOption("--sleep-interval", fmt.Sprintf("%v", opts.UpdateInterval))
+	} else {
+		flags.Delete("--sleep-interval")
+	}
+	if opts.NotificationEnable {
+		flags.SetOption("--notify-file", fmt.Sprintf("/%s/%s", rteNotifierVolumeName, rteNotifierFileName))
+	}
+
+	flags.SetOption("--pods-fingerprint", strconv.FormatBool(opts.PFPEnable))
+
+	if plat == platform.Kubernetes {
+		flags.SetOption("--kubelet-config-file", fmt.Sprintf("/%s/config.yaml", rteKubeletDirVolumeName))
+	}
+	cntSpec.Args = flags.Argv()
+
+	cntSpec.VolumeMounts = append(cntSpec.VolumeMounts, rteContainerVolumeMounts...)
+	podSpec.Volumes = append(podSpec.Volumes, rtePodVolumes...)
+}
+
+func metricsPortForContainer(cntSpec *corev1.Container, portNum int) {
+	env := objectupdate.FindContainerEnvVarByName(cntSpec.Env, metricsPortEnvVarName)
+	if env != nil {
+		env.Value = strconv.Itoa(portNum)
+	} else {
+		cntSpec.Env = append(cntSpec.Env, corev1.EnvVar{
+			Name:  metricsPortEnvVarName,
+			Value: strconv.Itoa(portNum),
+		})
+	}
+
+	cp := objectupdate.FindContainerPortByName(cntSpec.Ports, metricsPortContainerPortName)
+	if cp != nil {
+		cp.ContainerPort = int32(portNum)
+	} else {
+		cntSpec.Ports = append(cntSpec.Ports, corev1.ContainerPort{
+			Name:          metricsPortContainerPortName,
+			ContainerPort: int32(portNum),
+		})
+	}
 }


### PR DESCRIPTION
This is a continuation of the effort to make the embedded manifests minimal and move most mutations in the `objectupdate` subpackages.

We still want to have an embedded skeleton as basis, but moving the mutations in the `objectupdate` subpkgs is meant to better support objects reconciliation.